### PR TITLE
Update/add params to workspace index router

### DIFF
--- a/app/controllers/api/work_spaces_controller.rb
+++ b/app/controllers/api/work_spaces_controller.rb
@@ -3,7 +3,7 @@ class Api::WorkSpacesController < ApplicationController
   before_action :set_work_space, only: [:show, :update, :destroy]
 
   def index
-    work_spaces = paginate @current_user.work_spaces
+    work_spaces = paginate @current_user.work_spaces.by_recently_updated
 
     work_spaces = ActiveModelSerializers::SerializableResource.new(work_spaces, {})
     render json: format_response(work_spaces: work_spaces), status: :ok

--- a/app/models/work_space.rb
+++ b/app/models/work_space.rb
@@ -3,6 +3,8 @@ class WorkSpace < ApplicationRecord
 
   WORK_SPACE_PARAMS = %i(name description).freeze
 
+  scope :by_recently_updated, -> { order(updated_at: :desc) }
+
   validates :name, presence: true,
   length: {minimum: Settings.validations.work_space.name.minimum,
             maximum: Settings.validations.work_space.name.maximum}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   namespace :api do
     resources :users, only: [:show, :create]
     resources :todos
-    resources :work_spaces
+    resources :work_spaces, except: [:index]
+    get 'work_spaces(/:page/:per_page)' => 'work_spaces#index'
   end
 end


### PR DESCRIPTION
## Why

There are currently no params for pagination, so I'd like to add it.
And the default display by updated_at is "ASC" I want to change it to "DESC" to be able to display newly added or updated workspaces to the top

## What
- Add optional params to workspace index router for pagination
- change pagination workspaces order by desc

## Other Information

Write other information if you have.
その他の情報があれば記載してください。
